### PR TITLE
Enable Renovate auto-merge for safe updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,18 @@
 {
   "extends": [
     "@tryghost:quietJS"
+  ],
+  "packageRules": [
+    {
+      "description": "Automerge safe dependency updates after CI passes",
+      "matchUpdateTypes": [
+        "digest",
+        "lockFileMaintenance",
+        "minor",
+        "patch",
+        "pin"
+      ],
+      "automerge": true
+    }
   ]
 }


### PR DESCRIPTION
Enables Renovate auto-merge for digest, lockfile, patch, minor, and pin updates after CI passes.

Major dependency upgrades remain manual.