### PR TITLE
Automerge GitHub Actions updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,13 @@
   ],
   "packageRules": [
     {
+      "description": "Automerge GitHub Actions updates after release-age and CI checks",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "automerge": true
+    },
+    {
       "description": "Automerge safe dependency updates after CI passes",
       "matchUpdateTypes": [
         "digest",


### PR DESCRIPTION
Configures Renovate to auto-merge all GitHub Actions updates once the inherited minimum release-age policy and CI requirements are satisfied.

This intentionally includes major GitHub Actions updates; normal package dependency major updates remain manual.